### PR TITLE
Hold lustre-client-module to prevent accidental kernel upgrade

### DIFF
--- a/src/LifecycleScripts/base-config/initsmhp.sh
+++ b/src/LifecycleScripts/base-config/initsmhp.sh
@@ -4,6 +4,9 @@
 
 set -exuo pipefail
 
+# Don't let new lustre client module brings in new kernel.
+echo "lustre-client-modules-aws hold" | sudo dpkg --set-selections
+
 BIN_DIR=$(dirname $(realpath ${BASH_SOURCE[@]}))
 chmod ugo+x $BIN_DIR/initsmhp/*.sh
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* To prevent accidental kernel upgrade.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
