### PR TITLE
Install a mock .deb package to prevent accidental upgrade to GPU driver

### DIFF
--- a/src/LifecycleScripts/base-config/initsmhp.sh
+++ b/src/LifecycleScripts/base-config/initsmhp.sh
@@ -10,6 +10,7 @@ echo "lustre-client-modules-aws hold" | sudo dpkg --set-selections
 BIN_DIR=$(dirname $(realpath ${BASH_SOURCE[@]}))
 chmod ugo+x $BIN_DIR/initsmhp/*.sh
 
+bash -x $BIN_DIR/initsmhp/mock-gpu-driver-deb.sh
 bash -x $BIN_DIR/initsmhp/disable-gui.sh
 
 declare -a PKGS_SCRIPTS=(

--- a/src/LifecycleScripts/base-config/initsmhp/mock-gpu-driver-deb.sh
+++ b/src/LifecycleScripts/base-config/initsmhp/mock-gpu-driver-deb.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+DRV_VERSION=$(modinfo -F version nvidia)
+DRV_VERSION_MAJOR=${DRV_VERSION%%.*}
+MOCK_PKG=libnvidia-compute-${DRV_VERSION_MAJOR}
+
+#apt-get -y -o DPkg::Lock::Timeout=120 update   # Most likely this has been been done by another script.
+apt-get -y -o DPkg::Lock::Timeout=120 install equivs
+
+apt-cache show ${MOCK_PKG}=${DRV_VERSION}-0ubuntu1 \
+    | egrep '^Package|^Version|^Provides' \
+    &> ${MOCK_PKG}
+
+equivs-build ${MOCK_PKG}
+dpkg -i ${MOCK_PKG}_*.deb
+echo "${MOCK_PKG} hold" | sudo dpkg --set-selections


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* prevent stuffs like `apt install gpustat` to upgrade GPU driver.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
